### PR TITLE
atomic : Remove recursive key construction since not required. Tests …

### DIFF
--- a/src/main/scala/uk/gov/hmrc/cache/repository/CacheRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/cache/repository/CacheRepository.scala
@@ -58,7 +58,7 @@ class CacheMongoRepository(collName: String, override val expireAfterSeconds: Lo
   )
 
   private def allKeys(json: JsValue): Seq[String] = json match {
-    case JsObject(fields) => fields.map(_._1) ++ fields.map(_._2).flatMap(allKeys)
+    case JsObject(fields) => fields.map(_._1)
     case JsArray(as) => as.flatMap(allKeys)
     case _ => Seq.empty[String]
   }

--- a/src/test/scala/uk/gov/hmrc/cache/repository/CacheRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/cache/repository/CacheRepositorySpec.scala
@@ -252,13 +252,18 @@ class CacheRepositorySpec extends WordSpecLike with Matchers with MongoSpecSuppo
 //    }
   }
 
-
   private trait TestSetup {
     lazy val sampleFormData1Json: JsValue = Json.parse( """{
                                                  |"form-field-username":"John Densemore",
                                                  |"form-field-password":"password1",
                                                  |"form-field-address-number":42,
-                                                 |"form-field-address-one":"The Door"
+                                                 |"form-field-address-one":"The Door",
+                                                 |"inner1" : {
+                                                 |  "a" : "inner data depth 1",
+                                                 |  "inner2" : {
+                                                 |    "b" : "inner data depth 2"
+                                                 |  }
+                                                 | }
                                                  |}""".stripMargin)
 
     lazy val sampleFormData2Json = Json.parse( """{


### PR DESCRIPTION
…extended to cover complex nested json.

The legacy tests in mongo caching only had simple non nested json examples. One of the json examples has been extended to cover a nested json structure. 