### PR TITLE
Scala 2.12 and play 2.5, 2.6 cross build and update to simple-reactivemongo 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: scala
-scala:
-- 2.11.7
-jdk:
-- oraclejdk8
+matrix:
+  include:
+    - scala: 2.11.12
+      env: PLAY_VERSION=2.5
+      jdk: oraclejdk8
+    - scala: 2.11.12
+      env: PLAY_VERSION=2.6
+      jdk: oraclejdk8
+    - scala: 2.12.8
+      env: PLAY_VERSION=2.6
+      jdk: oraclejdk8
+
 notifications:
   email:
     recipients:

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ val testDependencies = PlayCrossCompilation.dependencies(
 lazy val mongoCache = Project(libName, file("."))
     .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
     .settings(
-      majorVersion := 5,
+      majorVersion := 6,
       makePublicallyAvailableOnBintray := true,
       scalaVersion := "2.11.12",
       libraryDependencies ++= compileDependencies ++ testDependencies,

--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,44 @@
-import play.core.PlayVersion
 import sbt.Keys._
 import sbt._
 
 val libName = "mongo-caching"
 
-val compileDependencies = Seq(
-  "com.typesafe.play" %% "play"               % PlayVersion.current % "provided",
-  "uk.gov.hmrc"       %% "play-reactivemongo" % "6.4.0",
-  "uk.gov.hmrc"       %% "time"               % "3.0.0",
-  "uk.gov.hmrc"       %% "http-verbs"         % "9.1.0-play-25"
+val play25 = "2.5.19"
+
+val play26 = "2.6.20"
+
+val compileDependencies = PlayCrossCompilation.dependencies(
+  shared = Seq(
+    "uk.gov.hmrc"       %% "time"               % "3.3.0"
+  ),
+  play25 = Seq(
+    "com.typesafe.play" %% "play"                 % play25 % "provided",
+    "uk.gov.hmrc"       %% "simple-reactivemongo" % "7.14.0-play-25",
+    "uk.gov.hmrc"       %% "http-verbs"           % "9.3.0-play-25"
+  ),
+  play26 = Seq(
+    "com.typesafe.play" %% "play"                 % play26 % "provided",
+    "uk.gov.hmrc"       %% "simple-reactivemongo" % "7.14.0-play-26",
+    "uk.gov.hmrc"       %% "http-verbs"           % "9.3.0-play-26"
+  )
 )
 
-val testDependencies = Seq(
-  "uk.gov.hmrc"       %% "reactivemongo-test" % "2.0.0"             % "test",
-  "org.scalatest"     %% "scalatest"          % "3.0.5"             % "test",
-  "com.typesafe.play" %% "play-test"          % PlayVersion.current % "test",
-  "org.pegdown"       % "pegdown"             % "1.4.2"             % "test"
+
+val testDependencies = PlayCrossCompilation.dependencies(
+  shared = Seq(
+    "org.scalatest"     %% "scalatest"              % "3.0.5"             % "test",
+    "org.pegdown"       % "pegdown"                 % "1.4.2"             % "test"
+  ),
+  play25 = Seq(
+    "com.typesafe.play"      %% "play-test"          % play25              % "test",
+    "uk.gov.hmrc"            %% "reactivemongo-test" % "4.9.0-play-25"     % "test"
+  ),
+  play26 = Seq(
+    "com.typesafe.play"      %% "play-test"          % play26              % "test",
+    "uk.gov.hmrc"            %% "reactivemongo-test" % "4.9.0-play-26"     % "test"
+  )
 )
+
 
 lazy val mongoCache = Project(libName, file("."))
     .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
@@ -25,12 +47,10 @@ lazy val mongoCache = Project(libName, file("."))
       makePublicallyAvailableOnBintray := true,
       scalaVersion := "2.11.12",
       libraryDependencies ++= compileDependencies ++ testDependencies,
-      evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
       resolvers := Seq(
         "typesafe-releases" at "http://repo.typesafe.com/typesafe/releases/",
         Resolver.bintrayRepo("hmrc", "releases"),
         Resolver.jcenterRepo
       ),
-      crossScalaVersions := Seq("2.11.12"),
-      ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
-    )
+      crossScalaVersions := Seq("2.11.12", "2.12.8")
+    ).settings(PlayCrossCompilation.playCrossCompilationSettings)

--- a/project/PlayCorssCompilation.scala
+++ b/project/PlayCorssCompilation.scala
@@ -1,0 +1,4 @@
+import uk.gov.hmrc.playcrosscompilation.AbstractPlayCrossCompilation
+import uk.gov.hmrc.playcrosscompilation.PlayVersion.Play25
+
+object PlayCrossCompilation extends AbstractPlayCrossCompilation(defaultPlayVersion = Play25)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.17.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.13.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.17.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.15.0")

--- a/src/main/scala/uk/gov/hmrc/cache/model/Cache.scala
+++ b/src/main/scala/uk/gov/hmrc/cache/model/Cache.scala
@@ -20,7 +20,10 @@ import play.api.libs.json._
  import reactivemongo.bson.BSONObjectID
  import uk.gov.hmrc.mongo.CreationAndLastModifiedDetail
 
- case class Cache(id: Id, data: Option[JsValue] = None, modifiedDetails: CreationAndLastModifiedDetail = CreationAndLastModifiedDetail(), atomicId:Option[BSONObjectID]=None) extends Cacheable {
+ case class Cache(id: Id,
+                  data: Option[JsValue] = None,
+                  modifiedDetails: CreationAndLastModifiedDetail = CreationAndLastModifiedDetail(),
+                  atomicId:Option[BSONObjectID]=None) extends Cacheable {
 }
 
 object Cache {

--- a/src/main/scala/uk/gov/hmrc/cache/model/Id.scala
+++ b/src/main/scala/uk/gov/hmrc/cache/model/Id.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.cache.model
 
-import play.api.libs.json.{JsResult, JsString, JsValue}
+import play.api.libs.json.{JsError, JsResult, JsString, JsValue}
 
 case class Id(id: String)
 
@@ -33,7 +33,7 @@ object Id {
   private val idRead: Reads[Id] = new Reads[Id] {
     override def reads(js: JsValue): JsResult[Id] = js match {
       case v: JsString => v.validate[String].map(Id.apply)
-      case noParsed => throw new Exception(s"Could not read Json value of 'id' in $noParsed")
+      case noParsed => JsError(s"Could not read Json value of 'id' in $noParsed")
     }
   }
   implicit val idFormats = Format(idRead, idWrite)

--- a/src/main/scala/uk/gov/hmrc/cache/repository/CacheRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/cache/repository/CacheRepository.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.mongo._
 import scala.concurrent.{ExecutionContext, Future}
 
 
-trait CacheRepository extends Repository[Cache, Id] with UniqueIndexViolationRecovery {
+trait CacheRepository extends ReactiveRepository[Cache, Id] with UniqueIndexViolationRecovery {
 
   def createOrUpdate(id: Id, key: String, toCache: JsValue): Future[DatabaseUpdate[Cache]] = ???
 

--- a/src/main/scala/uk/gov/hmrc/cache/repository/CacheRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/cache/repository/CacheRepository.scala
@@ -20,9 +20,11 @@ import play.api.libs.json._
 import play.modules.reactivemongo.MongoDbConnection
 import reactivemongo.api.DB
 import reactivemongo.bson._
-import reactivemongo.play.json.BSONFormats
+import reactivemongo.core.commands.BSONCommandError
+import reactivemongo.play.json.commands.{DefaultJSONCommandError, JSONFindAndModifyCommand}
 import uk.gov.hmrc.cache.model.{Cache, Id}
 import uk.gov.hmrc.mongo._
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -34,6 +36,7 @@ trait CacheRepository extends ReactiveRepository[Cache, Id] with UniqueIndexViol
   protected def saveOrUpdate(findQuery: => Future[Option[Cache]], ifNotFound: => Future[Cache], modifiers: (Cache) => Cache)(implicit ec: ExecutionContext): Future[DatabaseUpdate[Cache]] = ???
 }
 
+@deprecated("Please use injected CacheMongoRepository to your class", since = "6.x")
 object CacheRepository extends MongoDbConnection {
 
   def apply(collectionNameProvidedBySource: String, expireAfterSeconds: Long, cacheFormats: Format[Cache])(implicit ec: ExecutionContext): CacheRepository = new CacheMongoRepository(collectionNameProvidedBySource, expireAfterSeconds, cacheFormats)
@@ -42,19 +45,13 @@ object CacheRepository extends MongoDbConnection {
 class CacheMongoRepository(collName: String, override val expireAfterSeconds: Long, cacheFormats: Format[Cache] = Cache.mongoFormats)(implicit mongo: () => DB, ec: ExecutionContext)
   extends ReactiveRepository[Cache, Id](collName, mongo, cacheFormats, Id.idFormats)
     with CacheRepository with TTLIndexing[Cache]
-    with AtomicUpdate[Cache]
     with BSONBuilderHelpers {
 
 
-  final val AtomicId="atomicId"
-  final val Id="_id"
+  final val AtomicId = "atomicId"
+  final val Id = "_id"
 
-  private def findByIdBSON(id: Id) = BSONDocument(Id -> BSONString(id.id))
-
-  private def modifierForCrudCredentialsBSON(time: Long): BSONDocument = BSONDocument(
-    "$set" -> BSONDocument("modifiedDetails.lastUpdated" -> BSONDateTime(time)),
-    "$setOnInsert" -> BSONDocument("modifiedDetails.createdAt" -> BSONDateTime(time))
-  )
+  import ReactiveMongoFormats._
 
   override def createOrUpdate(id: Id, key: String, toCache: JsValue): Future[DatabaseUpdate[Cache]] = {
 
@@ -62,24 +59,38 @@ class CacheMongoRepository(collName: String, override val expireAfterSeconds: Lo
 
       implicit time =>
 
-        val modifiers = List(
-          // Set the document and overwrite if already exists.
-          set(BSONDocument(s"${Cache.DATA_ATTRIBUTE_NAME}.$key" -> BSONFormats.toBSON(toCache).getOrElse(throw new IllegalArgumentException("Failed to build insert command!")))),
-          modifierForCrudCredentialsBSON(time.getMillis),
-          setOnInsert(BSONDocument(Id -> BSONString(id.id)))
-        ).reduceLeft(_ ++ _)
+        withCurrentTime { time =>
+          def upsert: Future[JSONFindAndModifyCommand.FindAndModifyResult] = findAndUpdate(
+            Json.obj(Id -> id.id),
+            Json.obj(
+              "$set" -> Json.obj(s"${Cache.DATA_ATTRIBUTE_NAME}.$key" -> toCache, "modifiedDetails.lastUpdated" -> time),
+              "$setOnInsert" -> Json.obj("modifiedDetails.createdAt" -> time, Id -> id.id, AtomicId -> BSONObjectID.generate())
+            ),
+            upsert = true,
+            fetchNewObject = true
+          ).recoverWith {
+            case e: DefaultJSONCommandError if e.code.contains(11000) => upsert
+          }
 
-        def upsert = atomicUpsert(findByIdBSON(id.id), modifiers, AtomicId)
+          def handleOutcome(outcome: JSONFindAndModifyCommand.FindAndModifyResult): Future[DatabaseUpdate[Cache]] = {
+            (outcome.lastError, outcome.result[Cache]) match {
+              case (Some(error), Some(value)) =>
+                println(value)
+                if (error.n > 0) {
+                  if (error.updatedExisting) {
+                    Future.successful(DatabaseUpdate(null, Updated(null, value)))
+                  } else {
+                    Future.successful(DatabaseUpdate(null, Saved(value)))
+                  }
+                } else {
+                  upsert flatMap handleOutcome
+                }
+              case _ => throw new EntityNotFoundException("Failed to receive updated object!")
+            }
+          }
 
-        recoverFromViolation(upsert, upsert)
+          upsert.flatMap(handleOutcome)
+        }
     }
   }
-
-  override def isInsertion(newRecordId: BSONObjectID, oldRecord: Cache) = {
-    oldRecord.atomicId match {
-      case Some(id) => newRecordId.equals(id)
-      case _        => false
-    }
-  }
-
 }

--- a/src/main/scala/uk/gov/hmrc/cache/repository/CacheRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/cache/repository/CacheRepository.scala
@@ -21,7 +21,6 @@ import play.modules.reactivemongo.MongoDbConnection
 import reactivemongo.api.DB
 import reactivemongo.api.commands.LastError
 import reactivemongo.bson._
-import reactivemongo.core.commands.BSONCommandError
 import reactivemongo.play.json.commands.{DefaultJSONCommandError, JSONFindAndModifyCommand}
 import uk.gov.hmrc.cache.model.{Cache, Id}
 import uk.gov.hmrc.mongo._

--- a/src/test/scala/uk/gov/hmrc/cache/TimeToLiveTestSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/cache/TimeToLiveTestSpec.scala
@@ -18,31 +18,30 @@ package uk.gov.hmrc.cache
 
 import org.scalatest.Matchers._
 import org.scalatest.WordSpecLike
-import play.api.test.FakeApplication
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers._
 
 class TimeToLiveTestSpec extends WordSpecLike {
 
   "TimeToLive" should {
     val conf = Map("cache.expiryInMinutes" -> "6")
-    val fakeApp = FakeApplication(additionalConfiguration = conf)
 
     "yield the default value when there is no config to read " in {
-      running(FakeApplication()) {
+      running(new GuiceApplicationBuilder().build()) {
         val ttl = new TimeToLive {}
         ttl.defaultExpireAfter should be(300)
       }
     }
 
     "read the 'cache.expiryInMinutes' config value " in {
-      running(fakeApp) {
+      running(new GuiceApplicationBuilder().configure(conf).build()) {
         val ttl = new TimeToLive {}
         ttl.defaultExpireAfter should be(360)
       }
     }
 
     "yield the default value when 'cache.expiryInMinutes' config is missing" in {
-      running(FakeApplication()) {
+      running(new GuiceApplicationBuilder().build()) {
         val ttl = new TimeToLive {}
         ttl.defaultExpireAfter should be(300)
       }

--- a/src/test/scala/uk/gov/hmrc/cache/repository/CacheRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/cache/repository/CacheRepositorySpec.scala
@@ -16,15 +16,16 @@
 
 package uk.gov.hmrc.cache.repository
 
-import org.scalatest.concurrent.Eventually
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.{BeforeAndAfterEach, Matchers, OptionValues, WordSpecLike}
 import play.api.libs.json.Json
 import reactivemongo.bson.{BSONLong, BSONObjectID}
 import uk.gov.hmrc.cache.model.{Cache, Id}
 import uk.gov.hmrc.mongo.{MongoSpecSupport, Saved, Updated}
 
 
-class CacheRepositorySpec extends WordSpecLike with Matchers with MongoSpecSupport with BeforeAndAfterEach with Eventually {
+class CacheRepositorySpec extends WordSpecLike with Matchers with MongoSpecSupport with BeforeAndAfterEach
+  with Eventually with OptionValues with IntegrationPatience {
 
   import scala.concurrent.ExecutionContext.Implicits.global
   import scala.concurrent.duration._
@@ -368,8 +369,7 @@ class CacheRepositorySpec extends WordSpecLike with Matchers with MongoSpecSuppo
       val modifiedRepository = repo("replaceIndex", 8888888)
       eventually {
         val index = await(modifiedRepository.collection.indexesManager.list()).find(index => index.eventualName == "lastUpdatedIndex")
-        index.isDefined shouldBe true
-        index.get.options.get("expireAfterSeconds").get shouldBe BSONLong(8888888)
+        index.value.options.get("expireAfterSeconds").value shouldBe BSONLong(8888888)
       }
     }
 


### PR DESCRIPTION
This PR depends on some others PR in hmrc ecosystem
* [cross build in `simple-reactivemongo`](https://github.com/hmrc/simple-reactivemongo/pull/65)
* [log4j bridge to slf4j for reactive-mongo](https://github.com/hmrc/simple-reactivemongo/pull/66)
* [corss build in `reactivemongo-test](https://github.com/hmrc/reactivemongo-test/pull/10)
When listed PR have been merge this PR needs to be updated to non SNAPSHOT versions.