### PR TITLE
BDOG-731 Restore broken retry for upserts with duplicate key violation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ matrix:
       env: PLAY_VERSION=2.7
       jdk: openjdk8
 
-cache:
-  directories:
-    - '$HOME/.ivy2/cache'
 services:
   - mongodb
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,14 @@ matrix:
       env: PLAY_VERSION=2.7
       jdk: openjdk8
 
-notifications:
-  email:
-    recipients:
-    - platform-engineering@digital.hmrc.gov.uk
-before_script:
-  - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
-  - "echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list"
-  - "sudo apt-get update"
-  - "sudo apt-get install -y mongodb-org"
-  - "sudo apt-get install -y mongodb-org=3.2.11 mongodb-org-server=3.2.11 mongodb-org-shell=3.2.11 mongodb-org-mongos=3.2.11 mongodb-org-tools=3.2.11"
-
-  - "sleep 15" #mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
-  - "mongo --version"
+cache:
+  directories:
+    - '$HOME/.ivy2/cache'
+services:
+  - mongodb
+addons:
+  apt:
+    sources:
+      - mongodb-3.0-precise
+    packages:
+      - mongodb-org-server

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,9 @@ val compileDependencies = PlayCrossCompilation.dependencies(
 val testDependencies = PlayCrossCompilation.dependencies(
   shared = Seq(
     "org.scalatest"     %% "scalatest"              % "3.0.5"             % Test,
-    "org.pegdown"       % "pegdown"                 % "1.6.0"             % Test
+    "org.scalacheck"    %% "scalacheck"             % "1.14.0"            % Test,
+    "org.pegdown"       % "pegdown"                 % "1.6.0"             % Test,
+    "org.slf4j"         % "slf4j-simple"            % "1.7.30"            % Test
   ),
   play25 = Seq(
     "com.typesafe.play"      %% "play-test"          % play25Version       % Test,
@@ -57,7 +59,7 @@ lazy val mongoCache = Project(libName, file("."))
       scalaVersion := "2.11.12",
       libraryDependencies ++= compileDependencies ++ testDependencies,
       resolvers := Seq(
-        "typesafe-releases" at "http://repo.typesafe.com/typesafe/releases/",
+        "typesafe-releases" at "https://repo.typesafe.com/typesafe/releases/",
         Resolver.bintrayRepo("hmrc", "releases"),
         Resolver.jcenterRepo
       ),

--- a/build.sbt
+++ b/build.sbt
@@ -33,8 +33,7 @@ val testDependencies = PlayCrossCompilation.dependencies(
   shared = Seq(
     "org.scalatest"     %% "scalatest"              % "3.0.5"             % Test,
     "org.scalacheck"    %% "scalacheck"             % "1.14.0"            % Test,
-    "org.pegdown"       % "pegdown"                 % "1.6.0"             % Test,
-    "org.slf4j"         % "slf4j-simple"            % "1.7.30"            % Test
+    "org.pegdown"       % "pegdown"                 % "1.6.0"             % Test
   ),
   play25 = Seq(
     "com.typesafe.play"      %% "play-test"          % play25Version       % Test,

--- a/src/main/scala/uk/gov/hmrc/cache/repository/CacheRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/cache/repository/CacheRepository.scala
@@ -83,7 +83,7 @@ class CacheMongoRepository(collName: String, override val expireAfterSeconds: Lo
     def hasDupeKeyViolation(ex: JsResultException) = (for {
       validationErrors <- ex.errors.flatMap(_._2)
       message <- validationErrors.messages
-      dupeKey = message matches ".*code=11000[^\\w\\d].*"
+      dupeKey = message.matches(".*code=11000[^\\w\\d].*")
     } yield dupeKey).contains(true)
 
     withCurrentTime { implicit time =>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <!-- Mute logging for reactivemongo to prevent spamming test output, causing
+      "The job exceeded the maximum log length, and has been terminated." on Travis-->
+    <logger name="reactivemongo" level="ERROR"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/src/test/scala/uk/gov/hmrc/cache/WordSpecLikeWithRetries.scala
+++ b/src/test/scala/uk/gov/hmrc/cache/WordSpecLikeWithRetries.scala
@@ -26,7 +26,7 @@ abstract class WordSpecLikeWithRetries extends WordSpecLike with Retries {
   protected[this] val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   // Number of times to rerun the test before giving up
-  val retries = 5
+  val retries = 20
 
   override def withFixture(test: NoArgTest): Outcome = {
     if (isRetryable(test)) withFixture(test, retries) else super.withFixture(test)

--- a/src/test/scala/uk/gov/hmrc/cache/WordSpecLikeWithRetries.scala
+++ b/src/test/scala/uk/gov/hmrc/cache/WordSpecLikeWithRetries.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cache
+
+import org.scalatest.{Failed, Outcome, Retries}
+import org.scalatest._
+import org.slf4j.{Logger, LoggerFactory}
+
+abstract class WordSpecLikeWithRetries extends WordSpecLike with Retries {
+  this: BeforeAndAfterEach =>
+
+  protected[this] val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  // Number of times to rerun the test before giving up
+  val retries = 5
+
+  override def withFixture(test: NoArgTest): Outcome = {
+    if (isRetryable(test)) withFixture(test, retries) else super.withFixture(test)
+  }
+
+  def withFixture(test: NoArgTest, count: Int): Outcome = {
+    beforeEach() // Be completely sure we're starting fresh, in the retried tests
+    logger.info(s"Running fixture, remaining retries: $count")
+    val outcome = super.withFixture(test)
+    outcome match {
+      case Failed(_) => if (count == 1)  super.withFixture(test) else withFixture(test, count - 1)
+      case other => other
+    }
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/cache/WordSpecLikeWithRetries.scala
+++ b/src/test/scala/uk/gov/hmrc/cache/WordSpecLikeWithRetries.scala
@@ -26,7 +26,7 @@ abstract class WordSpecLikeWithRetries extends WordSpecLike with Retries {
   protected[this] val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   // Number of times to rerun the test before giving up
-  val retries = 20
+  val retries = 50
 
   override def withFixture(test: NoArgTest): Outcome = {
     if (isRetryable(test)) withFixture(test, retries) else super.withFixture(test)


### PR DESCRIPTION
1. Updates the check for the E11000 duplicate key violation on upsert so that it reinstates the original behaviour that was lost after upgrading to the latest simple-reactivemongo. The exception is now tangled up inside a JsResultException that comes back from reactivemongo-play-json. This is an ugly fix, but has been restored to the same functionality it was previously
1. Add a limit of 3 retries to the upsert, as before it would retry endlessly
1. Add a test to specifically try to hit the exception that we're catching, using a non-recover version of the upsert method. This is to prevent a similar change as we just experienced in future, where the check was no longer catching the right exception, but the test was failing to pick it up and leading to false positive results.